### PR TITLE
Added tqdm progress bar for sequential and parallel downloads

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,8 @@ setuptools.setup(
     install_requires = [
         "requests >= 2.24.0",
         "joblib >= 0.16.0",
-        "Pillow >= 2.2.1"
+        "Pillow >= 2.2.1",
+        "tqdm >= 4.62.3"
     ],
     extras_require = {
         "dev": [


### PR DESCRIPTION
Hi, I used this library for my pet projects to build image classifiers and can't thank you enough given how Google has restricted image scraping.
While using the lib, I found that adding a tqdm progress bar while downloading helped me a lot as I was checking every now and then the contents in my folder. 
I took the liberty to add a TQDM based progress for both the sequential and parallel downloads and tested it rigorously for python versions 3.6, 3.7, 3.8 and 3.9 on a Windows 10 machine.
Also replicated the testing using a script as well as a jupyter notebook. (Check screenshots below) without it affecting any other functionality. 

Script based testing
![duck_terminal_test](https://user-images.githubusercontent.com/23210132/147868265-992bd940-9fb2-4031-884b-4efd468d700a.PNG)

Notebook based testing
![duck_notebook_test](https://user-images.githubusercontent.com/23210132/147868270-b9d8b974-cd98-4633-bbf1-158ecdd7e1e4.PNG)

In case you wish to merge this into master after reviewing the code, it would be great. Also if you wish that I make any changes to the code to make it further compliant with code formatting or preferred folder structure, please do let me know. 
For now the progress bar is by default shown always on calling the download function, if you wish to add a flag to toggle the displaying of progress bar, I would be happy to do those changes too. 